### PR TITLE
CI Jobs for Ubuntu 18.04.

### DIFF
--- a/nodes/x86_64_ubuntu_1804.json
+++ b/nodes/x86_64_ubuntu_1804.json
@@ -1,0 +1,23 @@
+{
+  "contact": {
+    "name": "Daniel R",
+    "email": "danramteke@gmail.com",
+    "company": ""
+  },
+  "node": {
+      "platform": "x86_64",
+      "os_version": "Ubuntu 18.04"
+  },
+  "jobs": [
+    {
+      "display_name": "Ubuntu 18.04 x86_64 (master)",
+      "branch": "master",
+      "preset": "buildbot_linux_1804"
+    },
+    {
+      "display_name": "Ubuntu 18.04 x86_64 (4.1)",
+      "branch": "swift-4.1-branch",
+      "preset": "buildbot_linux_1804"
+    }
+  ]
+}


### PR DESCRIPTION
Ubuntu 18.04 is the newest LTS release. Currently, the latest version of Ubuntu that Swift supports is 16.10, which is an Ubuntu version that Ubuntu doesn't support any more. (For example, the `apt-get` repos have been removed for Ubuntu 16.10.)

These jobs use the build preset merged into `master` here: https://github.com/apple/swift/pull/16435