### PR TITLE
ppc64le custom preset for 4.2 branch build.

### DIFF
--- a/nodes/ppc64le_16_04.json
+++ b/nodes/ppc64le_16_04.json
@@ -13,6 +13,11 @@
       "display_name": "Swift - ppc64le (Tools RA, Stdlib RD) (swift-4.1-branch)",
       "branch": "swift-4.1-branch",
       "preset": "buildbot_incremental_linux"
+    },
+    {
+      "display_name": "Swift - ppc64le (Tools RA, Stdlib RD) (swift-4.2-branch)",
+      "branch": "swift-4.2-branch",
+      "preset": "buildbot_linux_ppc64le,no_test"
     }
   ]
 }


### PR DESCRIPTION
This PR superseeds and invalidates https://github.com/apple/swift-community-hosted-continuous-integration/pull/8, which was created earlier.

This PR refers to and depends on https://github.com/apple/swift/pull/16884 which adds custom preset for ppc64le to utils/build-presets.ini file.