### PR TITLE
Add a build for Swift for TensorFlow on MacOS High Sierra

### DIFF
--- a/nodes/x86_64_macos_high_sierra_tensorflow.json
+++ b/nodes/x86_64_macos_high_sierra_tensorflow.json
@@ -1,0 +1,18 @@
+{
+  "contact": {
+    "name": "Richard Wei",
+    "email": "rxwei@google.com",
+    "company": "Google"
+  },
+  "node": {
+      "platform": "x86_64",
+      "os_version": "MacOS High Sierra"
+  },
+  "jobs": [
+    {
+      "display_name": "Swift for TensorFlow - MacOS High Sierra x86_64 (tensorflow)",
+      "branch": "tensorflow",
+      "preset": "tensorflow_test"
+    }
+  ]
+}


### PR DESCRIPTION
This is a MacOS build for Swift for TensorFlow, much like the existing
Swift for TensorFlow build for Ubuntu 16.04.
