### PR TITLE
Add a build for Swift for TensorFlow with a GPU on Ubuntu 16.04.

### DIFF
--- a/nodes/x86_64_ubuntu_16_04_tensorflow_gpu.json
+++ b/nodes/x86_64_ubuntu_16_04_tensorflow_gpu.json
@@ -1,0 +1,18 @@
+{
+  "contact": {
+    "name": "Richard Wei",
+    "email": "rxwei@google.com",
+    "company": "Google"
+  },
+  "node": {
+      "platform": "x86_64",
+      "os_version": "Ubuntu 16.04"
+  },
+  "jobs": [
+    {
+      "display_name": "Swift for TensorFlow - Ubuntu 16.04 Linux x86_64 with GPU (tensorflow)",
+      "branch": "tensorflow",
+      "preset": "tensorflow_test,gpu"
+    }
+  ]
+}


### PR DESCRIPTION
This is a build much like
      x86_64_ubuntu_16_04_tensorflow.json
but it exercises the GPU-related TensorFlow code paths.
Currently, the GPU used is an Nvidia P100.
