### PR TITLE
Remove swift-4.1-branch and add swift-5.0-branch

### DIFF
--- a/nodes/aarch64_ubuntu_16.04.json
+++ b/nodes/aarch64_ubuntu_16.04.json
@@ -15,14 +15,14 @@
       "preset": "buildbot_linux,no_test"
     },
     {
-      "display_name": "Swift - Ubuntu 16.04 Linux aarch64 (swift-4.1-branch)",
-      "branch": "swift-4.1-branch",
-      "preset": "buildbot_linux,no_test"
-    },
-    {
       "display_name": "Swift - Ubuntu 16.04 Linux aarch64 (swift-4.2-branch)",
       "branch": "swift-4.2-branch",
       "preset": "buildbot_linux,no_test"
-    }
+    },
+    {
+      "display_name": "Swift - Ubuntu 16.04 Linux aarch64 (swift-5.0-branch)",
+      "branch": "swift-5.0-branch",
+      "preset": "buildbot_linux,no_test"
+    },
   ]
 }


### PR DESCRIPTION
With the release of Swift 4.2 building 4.1 is no longer needed.
Time to start working towards Swift 5.0