### PR TITLE
Update ppc64le_ubuntu_16_04.json to support swift-5.1-branch on ppc64le(with and without test suites)

### DIFF
--- a/nodes/ppc64le_ubuntu_16_04.json
+++ b/nodes/ppc64le_ubuntu_16_04.json
@@ -10,14 +10,14 @@
   },
   "jobs": [
     {
-      "display_name": "Swift - ppc64le (Tools RA, Stdlib RD) (swift-4.1-branch)",
-      "branch": "swift-4.1-branch",
-      "preset": "buildbot_incremental_linux"
+      "display_name": "Swift - ppc64le (Tools RA, Stdlib RD, No test suites) (swift-5.1-branch)",
+      "branch": "swift-5.1-branch",
+      "preset": "buildbot_linux,no_test"
     },
     {
-      "display_name": "Swift - ppc64le (Tools RA, Stdlib RD) (swift-4.2-branch)",
-      "branch": "swift-4.2-branch",
-      "preset": "buildbot_linux_ppc64le,no_test"
+      "display_name": "Swift - ppc64le (Tools RA, Stdlib RD, All test suites) (swift-5.1-branch)",
+      "branch": "swift-5.1-branch",
+      "preset": "buildbot_linux"
     }
   ]
 }


### PR DESCRIPTION
Update ppc64le_ubuntu_16_04.json to support swift-5.1-branch on ppc64le(with and without test suites)