### PR TITLE
Update to Swift 5.1

### DIFF
--- a/nodes/aarch64_ubuntu_16.04.json
+++ b/nodes/aarch64_ubuntu_16.04.json
@@ -15,14 +15,9 @@
       "preset": "buildbot_linux,no_test"
     },
     {
-      "display_name": "Swift - Ubuntu 16.04 Linux aarch64 (swift-4.2-branch)",
-      "branch": "swift-4.2-branch",
+      "display_name": "Swift - Ubuntu 16.04 Linux aarch64 (swift-5.1-branch)",
+      "branch": "swift-5.1-branch",
       "preset": "buildbot_linux,no_test"
-    },
-    {
-      "display_name": "Swift - Ubuntu 16.04 Linux aarch64 (swift-5.0-branch)",
-      "branch": "swift-5.0-branch",
-      "preset": "buildbot_linux,no_test"
-    },
+    }
   ]
 }


### PR DESCRIPTION
As Swift 5.1 has now been released I would like to remove swift-4.2-branch and swift-5.0-branch builds and add the swift-5.1-branch.