### PR TITLE
Add Linux Ubuntu 18.04 Aarch64 CI nodes

### DIFF
--- a/nodes/aarch64_ubuntu_18.04.json
+++ b/nodes/aarch64_ubuntu_18.04.json
@@ -1,0 +1,23 @@
+{
+  "contact": {
+    "name": "Neil Jones",
+    "email": "neil@swift-arm.com",
+    "company": "FutureJones"
+  },
+  "node": {
+      "platform": "aarch64",
+      "os_version": "Ubuntu 18.04"
+  },
+  "jobs": [
+    {
+      "display_name": "Swift - Ubuntu 18.04 Linux aarch64 (master)",
+      "branch": "master",
+      "preset": "buildbot_linux,no_test"
+    },
+    {
+      "display_name": "Swift - Ubuntu 18.04 Linux aarch64 (swift-5.2-branch)",
+      "branch": "swift-5.2-branch",
+      "preset": "buildbot_linux,no_test"
+    }
+  ]
+}


### PR DESCRIPTION
@shahmishal
 Please add new nodes for Ubuntu 18.04 aarch64.
 Branches: 
`swift-5.2-branch`
` master`

There will be separate machines available for each branch. 
Thanks.