### PR TITLE
Add Linux Ubuntu 16.04 CI node for swift-5.2-branch

### DIFF
--- a/nodes/aarch64_ubuntu_16.04.json
+++ b/nodes/aarch64_ubuntu_16.04.json
@@ -18,6 +18,11 @@
       "display_name": "Swift - Ubuntu 16.04 Linux aarch64 (swift-5.1-branch)",
       "branch": "swift-5.1-branch",
       "preset": "buildbot_linux,no_test"
+    },
+    {
+      "display_name": "Swift - Ubuntu 16.04 Linux aarch64 (swift-5.2-branch)",
+      "branch": "swift-5.2-branch",
+      "preset": "buildbot_linux,no_test"
     }
   ]
 }


### PR DESCRIPTION
@shahmishal
 Please add an additional node for Ubuntu 16.04 aarch64.
 Branch:
` swift-5.2-branch `
This can be added to the existing Ubuntu 16.04 aarch64 CI machine. 

Thanks.