### PR TITLE
remove 5.2 node and change master node build to smoketest

### DIFF
--- a/nodes/aarch64_ubuntu_18.04.json
+++ b/nodes/aarch64_ubuntu_18.04.json
@@ -12,12 +12,7 @@
     {
       "display_name": "Swift - Ubuntu 18.04 Linux aarch64 (master)",
       "branch": "master",
-      "preset": "buildbot_linux,no_test"
-    },
-    {
-      "display_name": "Swift - Ubuntu 18.04 Linux aarch64 (swift-5.2-branch)",
-      "branch": "swift-5.2-branch",
-      "preset": "buildbot_linux,no_test"
+      "preset": "buildbot_linux,smoketest"
     }
   ]
 }


### PR DESCRIPTION
Part 2 of restructuring the aarch64 server resources.

This server has been upgraded from the AWS a1 arm to the new m6g. Build times have been reduced from nearly 3 hours to about 50 mins and should be suitable for PR testing. 