### PR TITLE
add new aarch64 linux nodes

### DIFF
--- a/nodes/aarch64_amazon_linux_2_docker.json
+++ b/nodes/aarch64_amazon_linux_2_docker.json
@@ -1,0 +1,18 @@
+{
+    "contact": {
+      "name": "Neil Jones",
+      "email": "neil@swift-arm.com",
+      "company": "FutureJones"
+    },
+    "node": {
+        "platform": "aarch64",
+        "os_version": "Amazon Linux 2"
+    },
+    "jobs": [
+      {
+        "display_name": "Swift - Amazon Linux 2 aarch64 (master)",
+        "branch": "master",
+        "preset": "buildbot_linux,no_test"
+      }
+    ]
+  }

--- a/nodes/aarch64_centos_8_docker.json
+++ b/nodes/aarch64_centos_8_docker.json
@@ -1,0 +1,18 @@
+{
+    "contact": {
+      "name": "Neil Jones",
+      "email": "neil@swift-arm.com",
+      "company": "FutureJones"
+    },
+    "node": {
+        "platform": "aarch64",
+        "os_version": "CentOS 8"
+    },
+    "jobs": [
+      {
+        "display_name": "Swift - CentOS 8 Linux aarch64 (master)",
+        "branch": "master",
+        "preset": "buildbot_linux,no_test"
+      }
+    ]
+  }

--- a/nodes/aarch64_ubuntu_18.04_docker.json
+++ b/nodes/aarch64_ubuntu_18.04_docker.json
@@ -1,0 +1,18 @@
+{
+    "contact": {
+      "name": "Neil Jones",
+      "email": "neil@swift-arm.com",
+      "company": "FutureJones"
+    },
+    "node": {
+        "platform": "aarch64",
+        "os_version": "Ubuntu 18.04"
+    },
+    "jobs": [
+      {
+        "display_name": "Swift - Ubuntu 18.04 Linux aarch64 (master)",
+        "branch": "master",
+        "preset": "buildbot_linux,no_test"
+      }
+    ]
+  }

--- a/nodes/aarch64_ubuntu_20.04_docker.json
+++ b/nodes/aarch64_ubuntu_20.04_docker.json
@@ -1,0 +1,18 @@
+{
+    "contact": {
+      "name": "Neil Jones",
+      "email": "neil@swift-arm.com",
+      "company": "FutureJones"
+    },
+    "node": {
+        "platform": "aarch64",
+        "os_version": "Ubuntu 20.04"
+    },
+    "jobs": [
+      {
+        "display_name": "Swift - Ubuntu 20.04 Linux aarch64 (master)",
+        "branch": "master",
+        "preset": "buildbot_linux,no_test"
+      }
+    ]
+  }


### PR DESCRIPTION
Part 3 of restructuring the aarch64 server resources.

Add new build nodes for -
* Amazon Linux 2
* CentOS 8
* Ubuntu 18.04
* Ubuntu 20.04

I have setup a docker hub repo with pre built images for these OS's to simplify the setup.
https://hub.docker.com/u/swiftarm
Details of Dockerfiles used are here - 
https://github.com/futurejones/swift-arm64/tree/master/swift-ci-docker

Sample of Jenkins pipeline I have been using to test docker images and server setup -
https://github.com/futurejones/swift-arm64/blob/master/swift-ci-docker/Jenkinsfiles/Jenkinsfile

@shahmishal The server is setup and should be all ready to go except for your user keys and docker permissions. Will these be the same as before?