### PR TITLE
remove Debian 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
    * PPC64LE for Ubuntu 16.04
    * AArch64 for Amazon Linux 2
    * AArch64 for CentOS 8
-   * AArch64 for Debian 10
    * AArch64 for Ubuntu 18.04
    * AArch64 for Ubuntu 20.04
    * Android


### PR DESCRIPTION
Sorry, added Debian 10 by mistake. We don't have a node for this yet.