### PR TITLE
Update Swift for TensorFlow nodes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
    * Fedora 27
    * ARMv7 for Debian "Stretch"
    * Ubuntu 16.04
-   * Ubuntu 16.04 for TensorFlow
+   * Ubuntu 18.04 for TensorFlow
+   * Ubuntu 18.04 with GPU for TensorFlow
    * PPC64LE for Ubuntu 16.04
    * AArch64 for Amazon Linux 2
    * AArch64 for CentOS 8
@@ -14,7 +15,6 @@
    * AArch64 for Ubuntu 20.04
    * Android
    * macOS 10.13 for TensorFlow
-   * Ubuntu 16.04 with a GPU for TensorFlow
    * Debian 9.5
 
 ## Add Nodes

--- a/nodes/x86_64_macos_high_sierra_tensorflow.json
+++ b/nodes/x86_64_macos_high_sierra_tensorflow.json
@@ -1,6 +1,6 @@
 {
   "contact": {
-    "name": "Richard Wei",
+    "name": "Swift for TensorFlow team",
     "email": "tf-swift-team+apple-ci@google.com",
     "company": "Google"
   },

--- a/nodes/x86_64_ubuntu_18_04_tensorflow.json
+++ b/nodes/x86_64_ubuntu_18_04_tensorflow.json
@@ -1,16 +1,16 @@
 {
   "contact": {
-    "name": "Richard Wei",
+    "name": "Swift for TensorFlow team",
     "email": "tf-swift-team+apple-ci@google.com",
     "company": "Google"
   },
   "node": {
       "platform": "x86_64",
-      "os_version": "Ubuntu 16.04"
+      "os_version": "Ubuntu 18.04"
   },
   "jobs": [
     {
-      "display_name": "Swift for TensorFlow - Ubuntu 16.04 Linux x86_64 (tensorflow)",
+      "display_name": "Swift for TensorFlow - Ubuntu 18.04 Linux x86_64 (tensorflow)",
       "branch": "tensorflow",
       "preset": "tensorflow_test",
       "email_notifications": ["tf-swift-team+apple-ci@google.com"]

--- a/nodes/x86_64_ubuntu_18_04_tensorflow_gpu.json
+++ b/nodes/x86_64_ubuntu_18_04_tensorflow_gpu.json
@@ -1,16 +1,16 @@
 {
   "contact": {
-    "name": "Richard Wei",
+    "name": "Swift for TensorFlow team",
     "email": "tf-swift-team+apple-ci@google.com",
     "company": "Google"
   },
   "node": {
       "platform": "x86_64",
-      "os_version": "Ubuntu 16.04"
+      "os_version": "Ubuntu 18.04"
   },
   "jobs": [
     {
-      "display_name": "Swift for TensorFlow - Ubuntu 16.04 Linux x86_64 with GPU (tensorflow)",
+      "display_name": "Swift for TensorFlow - Ubuntu 18.04 Linux x86_64 with GPU (tensorflow)",
       "branch": "tensorflow",
       "preset": "tensorflow_test,gpu",
       "email_notifications": ["tf-swift-team+apple-ci@google.com"]


### PR DESCRIPTION
Swift for TensorFlow nodes run Ubuntu 18.04 instead of Ubuntu 16.04.
This has been true for some time now, but the "Ubuntu 16.04" description never got updated.

---

@shahmishal: the current `Ubuntu 18.04 Linux x86_64 (tensorflow)` and `Ubuntu 18.04 Linux x86_64 with GPU (tensorflow)` CI machines have been corrupted, but we have two replacement machines ready.

Could you please help us set up the replacement machines with the CI system? We can share information for connecting to the machines via email, please let us know what information is needed.