### PR TITLE
Added Fedora 33 as a builder and removed Fedora 27 as it is no longer supported

### DIFF
--- a/nodes/x86_64_fedora_33.json
+++ b/nodes/x86_64_fedora_33.json
@@ -6,12 +6,12 @@
   },
   "node": {
       "platform": "x86_64",
-      "os_version": "Fedora 27"
+      "os_version": "Fedora 33"
   },
   "jobs": [
     {
-      "display_name": "Swift - Fedora 27 Linux x86_64 (master)",
-      "branch": "master",
+      "display_name": "Swift - Fedora 33 Linux x86_64 (main)",
+      "branch": "main",
       "preset": "buildbot_linux,no_test"
     }
   ]


### PR DESCRIPTION
Fedora 27 was EOL in 2018. Now that I have a non-AWS builder I can keep up with the updates to the builder as new versions of Fedora roll out.