### PR TITLE
Updated Fedora 33 to Fedora 34

### DIFF
--- a/nodes/x86_64_fedora_34.json
+++ b/nodes/x86_64_fedora_34.json
@@ -6,11 +6,11 @@
   },
   "node": {
       "platform": "x86_64",
-      "os_version": "Fedora 33"
+      "os_version": "Fedora 34"
   },
   "jobs": [
     {
-      "display_name": "Swift - Fedora 33 Linux x86_64 (main)",
+      "display_name": "Swift - Fedora 34 Linux x86_64 (main)",
       "branch": "main",
       "preset": "buildbot_linux,no_test"
     }


### PR DESCRIPTION
Updating Fedora 33 to 34. New versions of Fedora are rolled out roughly every six months and the previous version is quickly dropped from support. I will keep the node updated with the latest production release and update the json file as necessary.