### PR TITLE
Update Debian 9.5 node to 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
    * AArch64 for Ubuntu 20.04
    * Android
    * macOS 10.13 for TensorFlow
-   * Debian 9.5
+   * Debian 10
 
 ## Add Nodes
 

--- a/nodes/x86_64_debian_10.json
+++ b/nodes/x86_64_debian_10.json
@@ -5,12 +5,12 @@
   },
   "node": {
       "platform": "Linux x86_64",
-      "os_version": "Debian 9.5"
+      "os_version": "Debian 10"
   },
   "jobs": [
     {
-      "display_name": "Swift - Debian 9.5 Linux x86_64 (master)",
-      "branch": "master",
+      "display_name": "Swift - Debian 10 Linux x86_64 (main)",
+      "branch": "main",
       "preset": "buildbot_incremental_linux"
     }
   ]


### PR DESCRIPTION
Following up on https://github.com/apple/swift-community-hosted-continuous-integration/pull/16#issuecomment-891278442, I have re-installed the server from scratch a while ago and it’s now a Debian 10.
If the public SSH key of the Jenkins node has not changed it should still work (IP and username are the same).