### PR TITLE
Mention wasm32 Ubuntu 20.04 node in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
    * Android
    * macOS 10.13 for TensorFlow
    * Debian 9.5
+   * wasm32 cross-compiled from Ubuntu 20.04
 
 ## Add Nodes
 


### PR DESCRIPTION
This is a follow-up to #42, where the node itself was added.