### PR TITLE
Updated Fedora node from 34 to 35

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [Swift Community-Hosted CI](https://ci-external.swift.org) is an extension of Swift CI that allows the community to add additional platforms. Community members can volunteer to host new platforms and they are responsible for maintaining the host nodes. The maintainer will provide a build preset which will be periodically built on the node. This allows the Swift community to see the impact of changes on a greater range of platforms.
 
 ## Current List of Nodes
-   * Fedora 33
+   * Fedora 35
    * Fedora Rawhide
    * ARMv7 for Debian "Stretch"
    * Ubuntu 16.04

--- a/nodes/x86_64_fedora_35.json
+++ b/nodes/x86_64_fedora_35.json
@@ -6,11 +6,11 @@
   },
   "node": {
       "platform": "x86_64",
-      "os_version": "Fedora 34"
+      "os_version": "Fedora 35"
   },
   "jobs": [
     {
-      "display_name": "Swift - Fedora 34 Linux x86_64 (main)",
+      "display_name": "Swift - Fedora 35 Linux x86_64 (main)",
       "branch": "main",
       "preset": "buildbot_linux,no_test"
     }


### PR DESCRIPTION
Fedora 35 has been released and is now the most current production version of Fedora; this PR updates the info to reflect this.