### PR TITLE
Update wasm32_ubuntu_20.04.json

### DIFF
--- a/nodes/wasm32_ubuntu_20.04.json
+++ b/nodes/wasm32_ubuntu_20.04.json
@@ -12,7 +12,7 @@
     {
       "display_name": "Swift - WebAssembly (wasm32) (Tools RA, Stdlib RA) (main)",
       "branch": "main",
-      "preset": "buildbot_incremental_linux_crosscompile_wasm",
+      "preset": "buildbot_linux_crosscompile_wasm",
       "email_notifications": ["apple-ci@swiftwasm.org"]
     }
   ]


### PR DESCRIPTION
The old one doesn't actually cross compile anything, but just tests cross compiler with Wasm backend. The new one actually cross-build stdlib and run more tests.